### PR TITLE
Adds language/locale support to Payto URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,7 +11,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Environment Details:
+        **Environment Details:**
 
   - type: input
     id: flutter_version
@@ -76,7 +76,7 @@ body:
     attributes:
       label: Package Version
       description: Version of flutter_paytorl package you're using
-      placeholder: e.g., 0.1.0
+      placeholder: e.g., 0.1.4
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - 🧪 **Tested**: Comprehensive test coverage
 - 🌲 **Tree Shaking**: Zero dependencies, no side effects
 - 📱 **Cross Platform**: Supports Android, iOS, Web, macOS, Windows, Linux, and Wasm
+- 🌍 **Internationalization**: Built-in language/locale support
 
 ## Installation
 
@@ -24,7 +25,7 @@ Add `flutter_paytorl` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_paytorl: ^0.1.0
+  flutter_paytorl: ^0.1.4
 ```
 
 Or install via command line:
@@ -62,6 +63,15 @@ void main() {
   payto.colorForeground = '000000';  // Black foreground
   print(payto.colorBackground); // 'ff0000'
 
+  // Language/locale support
+  payto.language = 'en-us';  // Set language to US English
+  print(payto.language);     // 'en-us'
+
+  // Parse existing language parameter
+  final localizedPayto = Payto('payto://example/address?lang=es-mx&amount=50');
+  print(localizedPayto.language); // 'es-mx'
+  print(localizedPayto.amount);   // '50'
+
   // ACH payment examples
   final achPayto1 = Payto('payto://ach/123456789/1234567'); // With routing number
   print(achPayto1.routingNumber); // 123456789
@@ -78,6 +88,45 @@ void main() {
   print(geoPayto.location); // '51.5074,0.1278'
 }
 ```
+
+### Language/Locale Support
+
+The library supports language and locale specification through the `lang` query parameter:
+
+```dart
+// Two-letter language codes
+payto.language = 'en';  // English
+payto.language = 'es';  // Spanish
+payto.language = 'fr';  // French
+
+// Locale format (language-region)
+payto.language = 'en-us';  // US English
+payto.language = 'en-gb';  // British English
+payto.language = 'es-mx';  // Mexican Spanish
+payto.language = 'fr-ca';  // Canadian French
+
+// Mixed case is automatically normalized
+payto.language = 'En-Us';  // Normalized to 'en-us'
+payto.language = 'ES-MX';  // Normalized to 'es-mx'
+
+// Parse from URL
+final payto = Payto('payto://example/address?lang=de-de&amount=100');
+print(payto.language); // 'de-de'
+```
+
+**Valid formats:**
+
+- ✅ `en` (two-letter language code)
+- ✅ `en-us` (locale format, lowercase)
+- ✅ `en-US` (locale format, mixed case)
+- ✅ `en-Us` (locale format, mixed case)
+
+**Invalid formats:**
+
+- ❌ `EN-US` (all uppercase)
+- ❌ `eng` (three letters)
+- ❌ `en-us-extra` (invalid format)
+- ❌ `en_us` (wrong separator)
 
 ## API Reference
 
@@ -107,6 +156,7 @@ Creates a new Payto instance from a payto URL string.
 | `donate` | `bool?` | Donation flag |
 | `fiat` | `String?` | Fiat currency code (case-insensitive) |
 | `iban` | `String?` | International Bank Account Number (case-insensitive) |
+| `language` | `String?` | Language/locale code (2-letter or locale format) |
 | `location` | `String?` | Location data (format depends on void type) |
 | `message` | `String?` | Payment message |
 | `network` | `String?` | Network identifier (case-insensitive) |

--- a/lib/src/models/payto_json.dart
+++ b/lib/src/models/payto_json.dart
@@ -57,6 +57,9 @@ class PaytoJson {
   /// Item description (max 40 chars)
   final String? item;
 
+  /// Language/locale code (2-letter or locale format)
+  final String? language;
+
   /// Location data (format depends on void type)
   final String? location;
 
@@ -129,6 +132,7 @@ class PaytoJson {
     required this.href,
     required this.iban,
     required this.item,
+    required this.language,
     required this.location,
     required this.message,
     required this.network,
@@ -169,6 +173,7 @@ class PaytoJson {
         href: json['href'] as String? ?? '',
         iban: json['iban'] as String?,
         item: json['item'] as String?,
+        language: json['language'] as String?,
         location: json['location'] as String?,
         message: json['message'] as String?,
         network: json['network'] as String? ?? '',
@@ -209,6 +214,7 @@ class PaytoJson {
         if (href.isNotEmpty) 'href': href,
         if (iban != null) 'iban': iban,
         if (item != null) 'item': item,
+        if (language != null) 'language': language,
         if (location != null) 'location': location,
         if (message != null) 'message': message,
         if (network.isNotEmpty) 'network': network,

--- a/lib/src/payto.dart
+++ b/lib/src/payto.dart
@@ -763,6 +763,7 @@ class Payto {
         href: href,
         iban: iban,
         item: item,
+        language: language,
         location: location,
         message: message,
         network: network,
@@ -812,5 +813,48 @@ class Payto {
         ..remove('color-f');
       _uri = _uri.replace(queryParameters: newParams);
     }
+  }
+
+  /// Gets language/locale code
+  String? get language {
+    final langValue = _uri.queryParameters['lang'];
+    if (langValue != null) {
+      // Convert to lowercase for consistency
+      return langValue.toLowerCase();
+    }
+    return null;
+  }
+
+  /// Sets language/locale code
+  set language(String? value) {
+    if (value != null) {
+      // Validate the language format (2-letter code or locale format)
+      if (!_isValidLanguageCode(value)) {
+        throw PaytoException('Invalid language format. Must be a 2-letter language code (e.g., "en") or locale format (e.g., "en-us")');
+      }
+      final normalizedValue = value.toLowerCase();
+      _uri = _uri.replace(
+        queryParameters: {..._uri.queryParameters, 'lang': normalizedValue},
+      );
+    } else {
+      final newParams = Map<String, String>.from(_uri.queryParameters)
+        ..remove('lang');
+      _uri = _uri.replace(queryParameters: newParams);
+    }
+  }
+
+  /// Helper method to validate language codes
+  bool _isValidLanguageCode(String code) {
+    // Check for 2-letter language code (e.g., "en", "es", "fr")
+    if (code.length == 2 && RegExp(r'^[a-z]{2}$').hasMatch(code)) {
+      return true;
+    }
+
+    // Check for locale format (e.g., "en-us", "es-mx", "fr-ca", "en-US", "en-Us")
+    if (RegExp(r'^[a-z]{2}-[a-zA-Z]{2}$').hasMatch(code)) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/lib/src/payto.dart
+++ b/lib/src/payto.dart
@@ -830,7 +830,8 @@ class Payto {
     if (value != null) {
       // Validate the language format (2-letter code or locale format)
       if (!_isValidLanguageCode(value)) {
-        throw PaytoException('Invalid language format. Must be a 2-letter language code (e.g., "en") or locale format (e.g., "en-us")');
+        throw PaytoException(
+            'Invalid language format. Must be a 2-letter language code (e.g., "en") or locale format (e.g., "en-us")');
       }
       final normalizedValue = value.toLowerCase();
       _uri = _uri.replace(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_paytorl
 description: A Flutter library for handling Payto Resource Locators (PRLs). Based on the URL API and provides additional functionality for managing PRLs.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/bchainhub/flutter_paytorl
 repository: https://github.com/bchainhub/flutter_paytorl
 documentation: https://github.com/bchainhub/flutter_paytorl#readme

--- a/test/payto_test.dart
+++ b/test/payto_test.dart
@@ -291,7 +291,8 @@ void main() {
       expect(() => payto.language = 'eng', throwsA(isA<PaytoException>()));
       expect(() => payto.language = 'e', throwsA(isA<PaytoException>()));
       expect(() => payto.language = 'english', throwsA(isA<PaytoException>()));
-      expect(() => payto.language = 'en-us-extra', throwsA(isA<PaytoException>()));
+      expect(
+          () => payto.language = 'en-us-extra', throwsA(isA<PaytoException>()));
       expect(() => payto.language = 'en_us', throwsA(isA<PaytoException>()));
       expect(() => payto.language = 'EN-US', throwsA(isA<PaytoException>()));
       expect(() => payto.language = 'EN', throwsA(isA<PaytoException>()));
@@ -305,7 +306,8 @@ void main() {
     });
 
     test('should handle language in complex URL', () {
-      final payto = Payto('payto://xcb/address?amount=10&lang=es-mx&fiat=eur&message=test');
+      final payto = Payto(
+          'payto://xcb/address?amount=10&lang=es-mx&fiat=eur&message=test');
       expect(payto.language, 'es-mx');
       expect(payto.amount, '10');
       expect(payto.fiat, 'eur');

--- a/test/payto_test.dart
+++ b/test/payto_test.dart
@@ -201,4 +201,125 @@ void main() {
       expect(payto.deadline, timestamp);
     });
   });
+
+  group('Language/Locale Handling', () {
+    test('should handle two-letter language codes', () {
+      final payto = Payto('payto://example/address?lang=en');
+      expect(payto.language, 'en');
+    });
+
+    test('should handle locale format', () {
+      final payto = Payto('payto://example/address?lang=en-us');
+      expect(payto.language, 'en-us');
+    });
+
+    test('should normalize uppercase language codes', () {
+      final payto = Payto('payto://example/address?lang=EN');
+      expect(payto.language, 'en');
+    });
+
+    test('should normalize mixed case locale', () {
+      final payto = Payto('payto://example/address?lang=En-Us');
+      expect(payto.language, 'en-us');
+    });
+
+    test('should handle multiple query parameters with language', () {
+      final payto = Payto('payto://example/address?amount=10&lang=es&fiat=eur');
+      expect(payto.language, 'es');
+      expect(payto.amount, '10');
+      expect(payto.fiat, 'eur');
+    });
+
+    test('should set language code', () {
+      final payto = Payto('payto://example/address');
+      payto.language = 'fr';
+      expect(payto.language, 'fr');
+      expect(payto.toString(), contains('lang=fr'));
+    });
+
+    test('should set locale format', () {
+      final payto = Payto('payto://example/address');
+      payto.language = 'es-mx';
+      expect(payto.language, 'es-mx');
+      expect(payto.toString(), contains('lang=es-mx'));
+    });
+
+    test('should normalize mixed case input', () {
+      final payto = Payto('payto://example/address');
+      payto.language = 'de-De';
+      expect(payto.language, 'de-de');
+      expect(payto.toString(), contains('lang=de-de'));
+    });
+
+    test('should remove language when set to null', () {
+      final payto = Payto('payto://example/address?lang=en');
+      expect(payto.language, 'en');
+
+      payto.language = null;
+      expect(payto.language, null);
+      expect(payto.toString(), isNot(contains('lang=')));
+    });
+
+    test('should validate two-letter language codes', () {
+      final payto = Payto('payto://example/address');
+
+      // Valid codes
+      expect(() => payto.language = 'en', returnsNormally);
+      expect(() => payto.language = 'es', returnsNormally);
+      expect(() => payto.language = 'fr', returnsNormally);
+      expect(() => payto.language = 'de', returnsNormally);
+    });
+
+    test('should validate locale format', () {
+      final payto = Payto('payto://example/address');
+
+      // Valid locales
+      expect(() => payto.language = 'en-us', returnsNormally);
+      expect(() => payto.language = 'es-mx', returnsNormally);
+      expect(() => payto.language = 'fr-ca', returnsNormally);
+      expect(() => payto.language = 'de-de', returnsNormally);
+      expect(() => payto.language = 'en-US', returnsNormally);
+      expect(() => payto.language = 'es-MX', returnsNormally);
+      expect(() => payto.language = 'en-Us', returnsNormally);
+      expect(() => payto.language = 'es-Mx', returnsNormally);
+    });
+
+    test('should reject invalid language codes', () {
+      final payto = Payto('payto://example/address');
+
+      // Invalid codes
+      expect(() => payto.language = 'eng', throwsA(isA<PaytoException>()));
+      expect(() => payto.language = 'e', throwsA(isA<PaytoException>()));
+      expect(() => payto.language = 'english', throwsA(isA<PaytoException>()));
+      expect(() => payto.language = 'en-us-extra', throwsA(isA<PaytoException>()));
+      expect(() => payto.language = 'en_us', throwsA(isA<PaytoException>()));
+      expect(() => payto.language = 'EN-US', throwsA(isA<PaytoException>()));
+      expect(() => payto.language = 'EN', throwsA(isA<PaytoException>()));
+    });
+
+    test('should include language in JSON object', () {
+      final payto = Payto('payto://example/address?lang=fr');
+      final json = payto.toJsonObject();
+
+      expect(json.language, 'fr');
+    });
+
+    test('should handle language in complex URL', () {
+      final payto = Payto('payto://xcb/address?amount=10&lang=es-mx&fiat=eur&message=test');
+      expect(payto.language, 'es-mx');
+      expect(payto.amount, '10');
+      expect(payto.fiat, 'eur');
+      expect(payto.message, 'test');
+    });
+
+    test('should preserve language when modifying other properties', () {
+      final payto = Payto('payto://example/address?lang=de');
+      payto.amount = '20';
+      payto.message = 'updated';
+
+      expect(payto.language, 'de');
+      expect(payto.amount, '20');
+      expect(payto.message, 'updated');
+    });
+  });
 }


### PR DESCRIPTION
Adds the ability to specify language and locale in Payto URLs using the `lang` parameter. This allows for internationalization and localization of payment requests.

It includes validation for valid language/locale formats. Also updates the package version to 0.1.4.