### PR TITLE
Adds support for INTRA payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ void main() {
   print(achPayto1.routingNumber); // 123456789
   print(achPayto1.accountNumber); // 1234567
 
+  // INTRA payment examples (European inter-bank transfers)
+  final intraPayto = Payto('payto://intra/pingchb2/cb1958b39698a44bdae37f881e68dce073823a48a631?amount=usd:20');
+  print(intraPayto.bic); // 'PINGCHB2'
+  print(intraPayto.accountNumber); // 'cb1958b39698a44bdae37f881e68dce073823a48a631'
+  print(intraPayto.amount); // 'usd:20'
+  print(intraPayto.value); // 20
+
   // UPI/PIX payment examples (case-insensitive email)
   final upiPayto = Payto('payto://upi/USER@example.com');
   print(upiPayto.accountAlias); // 'user@example.com'
@@ -108,7 +115,7 @@ Creates a new Payto instance from a payto URL string.
 | Property | Type | Description |
 |----------|------|-------------|
 | `accountAlias` | `String?` | Email address for UPI/PIX payments (case-insensitive) |
-| `accountNumber` | `int?` | Account number (7-14 digits) for ACH payments |
+| `accountNumber` | `dynamic` | Account number for ACH payments (int) or INTRA payments (String) |
 | `address` | `String?` | Payment address |
 | `amount` | `String?` | Payment amount with optional currency prefix |
 | `asset` | `String?` | Asset type or contract address |

--- a/lib/src/models/payto_json.dart
+++ b/lib/src/models/payto_json.dart
@@ -3,8 +3,8 @@ class PaytoJson {
   /// Email address for UPI/PIX payments (case-insensitive)
   final String? accountAlias;
 
-  /// Account number (7-14 digits) for ACH payments
-  final int? accountNumber;
+  /// Account number for ACH payments (int) or INTRA payments (String)
+  final dynamic accountNumber;
 
   /// Payment address
   final String? address;
@@ -159,7 +159,7 @@ class PaytoJson {
   /// Creates a PaytoJson instance from a JSON map
   factory PaytoJson.fromJson(Map<String, dynamic> json) => PaytoJson(
         accountAlias: json['accountAlias'] as String?,
-        accountNumber: json['accountNumber'] as int?,
+        accountNumber: json['accountNumber'],
         address: json['address'] as String?,
         amount: json['amount'] as String?,
         asset: json['asset'] as String?,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_paytorl
 description: A Flutter library for handling Payto Resource Locators (PRLs). Based on the URL API and provides additional functionality for managing PRLs.
-version: 0.1.5
+version: 0.1.6
 homepage: https://github.com/bchainhub/flutter_paytorl
 repository: https://github.com/bchainhub/flutter_paytorl
 documentation: https://github.com/bchainhub/flutter_paytorl#readme

--- a/test/payto_test.dart
+++ b/test/payto_test.dart
@@ -72,6 +72,94 @@ void main() {
     });
   });
 
+  group('INTRA Payments', () {
+    test('should parse INTRA payment with BIC and account', () {
+      final intraPayto = Payto(
+          'payto://intra/pingchb2/cb1958b39698a44bdae37f881e68dce073823a48a631');
+
+      expect(intraPayto.bic, 'PINGCHB2');
+      expect(intraPayto.accountNumber,
+          'cb1958b39698a44bdae37f881e68dce073823a48a631');
+    });
+
+    test('should parse INTRA payment with amount', () {
+      final intraPayto = Payto(
+          'payto://intra/pingchb2/cb1958b39698a44bdae37f881e68dce073823a48a631?amount=usd:20');
+
+      expect(intraPayto.bic, 'PINGCHB2');
+      expect(intraPayto.accountNumber,
+          'cb1958b39698a44bdae37f881e68dce073823a48a631');
+      expect(intraPayto.amount, 'usd:20');
+      expect(intraPayto.value, 20);
+      expect(intraPayto.asset, 'usd');
+    });
+
+    test('should parse INTRA payment with only BIC', () {
+      final intraPayto = Payto('payto://intra/DEUTDEFF500');
+
+      expect(intraPayto.bic, 'DEUTDEFF500');
+      expect(intraPayto.accountNumber, 'DEUTDEFF500');
+    });
+
+    test('should set BIC for INTRA payment', () {
+      final intraPayto = Payto('payto://intra/address');
+      intraPayto.bic = 'CHASUS33XXX';
+
+      expect(intraPayto.bic, 'CHASUS33XXX');
+    });
+
+    test('should set account number for INTRA payment', () {
+      final intraPayto = Payto('payto://intra/DEUTDEFF500/oldaccount');
+      intraPayto.accountNumber = 'ACC123456';
+
+      expect(intraPayto.bic, 'DEUTDEFF500');
+      expect(intraPayto.accountNumber, 'ACC123456');
+    });
+
+    test('should validate BIC format for INTRA', () {
+      final intraPayto = Payto('payto://intra/address');
+
+      expect(
+        () => intraPayto.bic = 'invalid',
+        throwsA(isA<PaytoException>()),
+      );
+    });
+
+    test('should handle hexadecimal account numbers', () {
+      final intraPayto = Payto('payto://intra/pingchb2/abc123def456');
+
+      expect(intraPayto.accountNumber, 'abc123def456');
+      expect(intraPayto.bic, 'PINGCHB2');
+    });
+
+    test('should handle long alphanumeric account numbers', () {
+      final intraPayto = Payto(
+          'payto://intra/DEUTDEFF500/cb1958b39698a44bdae37f881e68dce073823a48a631');
+
+      expect(intraPayto.accountNumber,
+          'cb1958b39698a44bdae37f881e68dce073823a48a631');
+      expect(intraPayto.bic, 'DEUTDEFF500');
+    });
+
+    test('should return uppercase BIC', () {
+      final intraPayto = Payto('payto://intra/deutdeff500');
+
+      expect(intraPayto.bic, 'DEUTDEFF500');
+    });
+
+    test('should include BIC and account in JSON', () {
+      final intraPayto = Payto(
+          'payto://intra/pingchb2/cb1958b39698a44bdae37f881e68dce073823a48a631?amount=usd:20');
+      final json = intraPayto.toJsonObject();
+
+      expect(json.bic, 'PINGCHB2');
+      expect(
+          json.accountNumber, 'cb1958b39698a44bdae37f881e68dce073823a48a631');
+      expect(json.amount, 'usd:20');
+      expect(json.value, 20);
+    });
+  });
+
   group('UPI/PIX Payments', () {
     test('should handle UPI email alias', () {
       final upiPayto = Payto('payto://upi/USER@example.com');


### PR DESCRIPTION
Extends functionality to handle INTRA payments, including parsing and validating BIC and account number.

Updates the `accountNumber` property to accept both int (for ACH) and String (for INTRA) account numbers.

Increments version to 0.1.6.